### PR TITLE
Check for missing subtitle

### DIFF
--- a/lynda/_extract.py
+++ b/lynda/_extract.py
@@ -157,7 +157,15 @@ class Lynda(ProgressBar):
     def _extract_subtitles(self, video_id):
         url =  CAPTIONS_URL.format(video_id=video_id)
         try:
-            subs = self._session.get(url).json()
+            subs_raw = self._session.get(url)
+            if "Status=\"NotFound\"" in subs_raw.content:
+                return {
+                    'type' : 'subtitle',
+                    'language' : 'en',
+                    'extension' : 'srt',
+                    'subtitle_data' : None,
+                    }
+            subs = subs_raw.json()
         except conn_error as e:
             print("")
             sys.stdout.write(fc + sd + "[" + fr + sb + "-" + fc + sd + "] : " + fr + sb + "Connection error : make sure your internet connection is working.\n")


### PR DESCRIPTION
Lynda returns invalid JSON if there are no subtitles. Potentially fixed #55 